### PR TITLE
Set $PATH when bundle install from internet [obvious fix]

### DIFF
--- a/lib/busser/runner_plugin/rspec.rb
+++ b/lib/busser/runner_plugin/rspec.rb
@@ -46,7 +46,7 @@ class Busser::RunnerPlugin::Rspec < Busser::RunnerPlugin::Base
         # Bundle install local completes quickly if the gems are already found locally
         # it fails if it needs to talk to the internet. The || below is the fallback
         # to the internet-enabled version. It's a speed optimization.
-        run("env PATH=#{ENV['PATH']}:#{Gem.bindir} bundle install --local || bundle install")
+        run("PATH=#{ENV['PATH']}:#{Gem.bindir}; bundle install --local || bundle install")
       end
 
       runner = File.expand_path(File.join(File.dirname(__FILE__), "..", "rspec", "runner.rb"))


### PR DESCRIPTION
Hi. Thank you for the reply.
I agree it is a small obvious fix.
