### PR TITLE
using --format documentation option to increase verbosity

### DIFF
--- a/lib/busser/runner_plugin/rspec.rb
+++ b/lib/busser/runner_plugin/rspec.rb
@@ -51,7 +51,7 @@ class Busser::RunnerPlugin::Rspec < Busser::RunnerPlugin::Base
       end
 
       runner = File.expand_path(File.join(File.dirname(__FILE__), "..", "rspec", "runner.rb"))
-      run_ruby_script!("#{runner} -I #{rspec_path} -I #{rspec_path}/lib #{rspec_path}")
+      run_ruby_script!("#{runner} --format documentation -I #{rspec_path} -I #{rspec_path}/lib #{rspec_path}")
     end
   end
 end


### PR DESCRIPTION
While writing tests suites, it's much simpler to debug what's going on if we have a more verbose output. Also more in line with the serverspec busser.