### PR TITLE
fix bundle install on windows

### DIFF
--- a/lib/busser/runner_plugin/rspec.rb
+++ b/lib/busser/runner_plugin/rspec.rb
@@ -40,7 +40,7 @@ class Busser::RunnerPlugin::Rspec < Busser::RunnerPlugin::Base
         # Bundle install local completes quickly if the gems are already found locally
         # it fails if it needs to talk to the internet. The || below is the fallback
         # to the internet-enabled version. It's a speed optimization.
-        run("PATH=#{ENV['PATH']}:#{Gem.bindir}; bundle install --local || bundle install")
+        run("#{Gem.bindir}/bundle install --local || #{Gem.bindir}/bundle install")
       end
 
       if File.exists?(setup_file)


### PR DESCRIPTION
shelling out on windows with backticks or `system()` does not yield a unix type shell. e.g.:

```
$ ruby -e 'puts `A=B; echo $A`'
-e:1:in ``': No such file or directory - A=B; echo $A (Errno::ENOENT)
	from -e:1:in `<main>'
```

This patch works for windows as well as unix as far as I can tell