### PR TITLE
Fix bundle install for windows

### DIFF
--- a/lib/busser/runner_plugin/rspec.rb
+++ b/lib/busser/runner_plugin/rspec.rb
@@ -36,11 +36,17 @@ class Busser::RunnerPlugin::Rspec < Busser::RunnerPlugin::Base
 
     Dir.chdir(rspec_path) do
 
-      if File.exists?(File.join(rspec_path, "Gemfile"))
+      # Referred from busser-serverspec
+      gemfile_path = File.join(rspec_path, 'Gemfile')
+      if File.exists?(gemfile_path)
         # Bundle install local completes quickly if the gems are already found locally
         # it fails if it needs to talk to the internet. The || below is the fallback
         # to the internet-enabled version. It's a speed optimization.
-        run("#{Gem.bindir}/bundle install --local || #{Gem.bindir}/bundle install")
+        banner('Bundle Installing..')
+        ENV['PATH'] = [ENV['PATH'], Gem.bindir, RbConfig::CONFIG['bindir']].join(File::PATH_SEPARATOR)
+        bundle_exec = "#{File.join(RbConfig::CONFIG['bindir'], 'ruby')} " +
+          "#{File.join(Gem.bindir, 'bundle')} install --gemfile #{gemfile_path}"
+        run("#{bundle_exec} --local || #{bundle_exec}")
       end
 
       if File.exists?(setup_file)


### PR DESCRIPTION
Used the code from busser-serverspec to fix this issue for Windows platform.

Exception on Windows platform with chef-client >=11.16:
```
       Installing Busser plugins: busser-rspec
       Plugin rspec installed (version 0.7.5)
-----> Running postinstall for rspec plugin
       Suite path directory C:/Users/vagrant/AppData/Local/Temp/verifier/suites does not exist, skipping.
       Transferring files to <default-windows-2012r2>
-----> Running rspec test suite
         run  C:/Users/vagrant/AppData/Local/Temp/verifier/gems/bin/bundle install --local || C:/Users/vagrant/AppData/Local/Temp/verifier/gems/bin/bundle install from "."
$$$$$$ '"ruby.exe"' is not recognized as an internal or external command,
$$$$$$ operable program or batch file.
$$$$$$ '"ruby.exe"' is not recognized as an internal or external command,
$$$$$$ operable program or batch file.
$$$$$$ C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/bundler-1.10.6/lib/bundler/resolver.rb:347:in `block in verify_gemfile_dependencies_are_found!': Could not find gem 'selenium-webdriver (~> 2.47) x86-mingw32' in any of the gem sources listed in your Gemfile or available on this machine. (Bundler::GemNotFound)
$$$$$$  from C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/bundler-1.10.6/lib/bundler/resolver.rb:325:in `each'
$$$$$$  from C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/bundler-1.10.6/lib/bundler/resolver.rb:325:in `verify_gemfile_dependencies_are_found!'
$$$$$$  from C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/bundler-1.10.6/lib/bundler/resolver.rb:198:in `start'
$$$$$$  from C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/bundler-1.10.6/lib/bundler/resolver.rb:182:in `resolve'
$$$$$$  from C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/bundler-1.10.6/lib/bundler/definition.rb:200:in `resolve'
$$$$$$  from C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/bundler-1.10.6/lib/bundler/definition.rb:140:in `specs'
$$$$$$  from C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/bundler-1.10.6/lib/bundler/definition.rb:185:in `specs_for'
$$$$$$  from C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/bundler-1.10.6/lib/bundler/definition.rb:174:in `requested_specs'
$$$$$$  from C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/bundler-1.10.6/lib/bundler/environment.rb:18:in `requested_specs'
$$$$$$  from C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/bundler-1.10.6/lib/bundler/runtime.rb:13:in `setup'
$$$$$$  from C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/bundler-1.10.6/lib/bundler.rb:127:in `setup'
$$$$$$  from C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/bundler-1.10.6/lib/bundler/setup.rb:18:in `<top (required)>'
$$$$$$  from C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:60:in `require'
$$$$$$  from C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:60:in `rescue in require'
$$$$$$  from C:/opscode/chef/embedded/lib/ruby/site_ruby/1.9.1/rubygems/custom_require.rb:35:in `require'
$$$$$$  from C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/busser-rspec-0.7.5/lib/busser/rspec/runner.rb:20:in `<main>'
$$$$$$ !!!!!! Ruby Script [C:/Users/vagrant/AppData/Local/Temp/verifier/gems/gems/busser-rspec-0.7.5/lib/busser/rspec/runner.rb -I C:/Users/vagrant/AppData/Local/Temp/verifier/suites/rspec -I C:/Users/vagrant/AppData/Local/Temp/verifier/suites/rspec/lib C:/Users/vagrant/AppData/Local/Temp/verifier/suites/rspec] exit code was 1
```