### PR TITLE
docs: rewrite the readme and add a contributing guide

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -3,7 +3,7 @@ require:
   - cookstyle/chefstyle
 
 AllCops:
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
   Exclude:
     - "vendor/**/*"
     - "spec/**/*"

--- a/.tailor
+++ b/.tailor
@@ -1,4 +1,0 @@
-Tailor.config do |config|
-  config.formatters "text"
-  config.file_set 'lib/**/*.rb'
-end

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,104 @@
+# Contributing to busser-rspec
+
+Thanks for taking the time to contribute. This document covers how to get the
+project running locally, how to check your work before opening a pull request,
+and the commit convention releases depend on.
+
+## Getting set up
+
+This plugin requires **Ruby 3.2 or newer**. Clone the repository and install the
+development dependencies:
+
+```bash
+git clone https://github.com/test-kitchen/busser-rspec.git
+cd busser-rspec
+bundle install
+```
+
+## Running the tests
+
+`rake` runs the whole suite:
+
+```bash
+bundle exec rake test
+```
+
+The tests are [cucumber](https://cucumber.io) features in `features/`. They
+drive the real `busser` executable through
+[aruba](https://github.com/cucumber/aruba) rather than calling the plugin's
+classes, so they cover it end to end: install the plugin into a throwaway
+Busser root, write a suite, run it, and check what came out. The step
+definitions they use are published by busser itself, in `lib/busser/cucumber.rb`.
+
+### How the feature sandbox works
+
+Features that install the plugin sandbox `GEM_HOME` into a temporary directory
+and strip bundler out of the environment, so a run never installs a gem into
+your bundle. Two details matter if you add or change one:
+
+* **Do not reintroduce bundler variables.** RubyGems re-requires
+  `bundler/setup` whenever `BUNDLER_SETUP` is present, and bundler then resets
+  `Gem.dir` to the bundle. Plugins install into `vendor/bundle` instead of the
+  sandbox, and the assertions that look in `GEM_HOME` fail. The
+  `a non bundler environment` step exists to clear this.
+* **The plugin is installed from the working tree.** With bundler out of the
+  way, `busser plugin install` would fetch the last release from RubyGems and
+  run *its* postinstall — so the suite would pass on code that is not in your
+  branch. The `this plugin is installed from the working tree` step builds the
+  gem from the gemspec and installs it into the sandbox first, which is what
+  makes the features test your change.
+
+## Linting
+
+CI runs three linters, all of which you can run locally:
+
+```bash
+bundle exec cookstyle --chefstyle   # Ruby
+yamllint --strict .                 # YAML
+markdownlint-cli2 "**/*.md" "!**/CHANGELOG*.md"
+```
+
+## Commit messages
+
+This project uses [Conventional Commits](https://www.conventionalcommits.org).
+Releases are automated, and the commit subject on `main` is what decides the
+next version number and what appears in the changelog.
+
+Pull requests are **squash merged, so the pull request title becomes that
+subject**. A CI check enforces the format on the title; the individual commits
+on your branch are not checked.
+
+| Prefix | Effect on the next release |
+| --- | --- |
+| `fix:` | Patch version bump |
+| `feat:` | Minor version bump |
+| `feat!:`, or a `BREAKING CHANGE:` footer | Minor bump, until this gem reaches 1.0 |
+| `chore:`, `docs:`, `ci:`, `test:`, `refactor:` | No release |
+
+For example:
+
+```text
+fix: install the plugin into GEM_HOME rather than the bundle
+feat: support a Gemfile alongside the suite
+ci: pin the shared workflow to a release
+```
+
+## Opening a pull request
+
+1. Fork the repository and create a branch for your change.
+2. Add or update tests. A bug fix should come with a test that fails without it.
+3. Run `bundle exec rake test` and the linters above.
+4. Open a pull request with a Conventional Commits title.
+
+## Releases
+
+Releases are handled by
+[release-please](https://github.com/googleapis/release-please). It watches
+commits landing on `main` and keeps a release pull request open with the next
+version number and the accumulated changelog. Merging that pull request tags the
+release and publishes the gem to RubyGems and GitHub Packages.
+
+Maintainers do not bump `lib/busser/rspec/version.rb` or edit
+`CHANGELOG.md` by hand; release-please owns both files. This gem is still pre-1.0, so
+`bump-minor-pre-major` is set and a breaking change takes the minor rather than
+graduating it to 1.0.

--- a/Gemfile
+++ b/Gemfile
@@ -3,13 +3,13 @@ source "https://rubygems.org"
 gemspec
 
 group :cookstyle do
-  gem "cookstyle", ">= 9.0.0"
+  gem "cookstyle", ">= 9.0"
 end
 
 group :test do
-  gem "aruba", ">= 2.0"
-  gem "base64" # cucumber needs it; not a default gem on Ruby 4.0
+  gem "aruba", ">= 2.4"
+  gem "base64", ">= 0.3" # cucumber needs it; not a default gem on Ruby 4.0
   gem "cucumber", ">= 11.1"
-  gem "rake"
+  gem "rake", ">= 13.4"
   gem "rspec", ">= 3.13"
 end

--- a/README.md
+++ b/README.md
@@ -1,67 +1,107 @@
-# Busser::RunnerPlugin::Rspec
+# busser-rspec
 
 [![Gem Version](https://badge.fury.io/rb/busser-rspec.svg)](https://badge.fury.io/rb/busser-rspec)
 
-A Busser runner plugin for Rspec
+A [Busser](https://github.com/test-kitchen/busser) runner plugin that runs
+[RSpec](https://rspec.info) examples as integration tests.
+
+Busser installs RSpec on the machine under test during postinstall, then runs
+the suite's `rspec` directory against it. Because the examples run on the
+machine itself rather than over SSH, they can assert on local files, services
+and commands directly.
 
 ## Status
 
-This software project is no longer under active development as it has no active maintainers. The software may continue to work for some or all use cases, but issues filed in GitHub will most likely not be triaged. If a new maintainer is interested in working on this project please come chat with us in #test-kitchen on Chef Community Slack.
+This software project is no longer under active development as it has no active
+maintainers. The software may continue to work for some or all use cases, but
+issues filed in GitHub will most likely not be triaged. If a new maintainer is
+interested in working on this project please come chat with us in #test-kitchen
+on Chef Community Slack.
 
-## Installation and Setup
+## Requirements
 
-Please read the Busser [plugin usage](plugin_usage) page for more details.
+Ruby 3.2 or newer, and busser 0.9.0 or newer. The plugin installs RSpec 3.13 or
+newer on the machine under test.
+
+## Installation
+
+Busser installs the plugin for you when Test Kitchen runs the suite, so there is
+usually nothing to do. To install it by hand:
+
+```bash
+busser plugin install busser-rspec
+```
 
 ## Usage
 
-Please put test files into [COOKBOOK]/test/integration/[SUITES]/rspec/
+Put your specs in the `rspec` directory of a suite:
 
 ```text
--- [COOKBOOK]
-  `-- test
-     `-- integration
-        `-- default
-           `-- rspec
-              `-- spec_helper.rb
-              `-- Gemfile
+test
+`-- integration
+    `-- default              # suite name
+        `-- rspec
+            |-- Gemfile              # optional
+            |-- setup-recipe.rb      # optional
+            |-- spec_helper.rb
+            `-- default_spec.rb
 ```
 
-You can specify your own test gem dependencies with a `Gemfile` under the `rspec` path, like this: `test/integration/<suite>/rspec/Gemfile`. Don't forget to put `gem "rspec"` there!
+The suite directory is passed to RSpec as the spec path, and both it and its
+`lib` subdirectory are added to the load path — so `require "spec_helper"` works
+from any spec without a relative path.
 
-## How do I ... ?
+```ruby
+describe "foobar::default" do
+  it "creates foobar.txt" do
+    expect(File).to exist("/usr/local/foobar.txt")
+  end
+end
+```
 
-### Change the rspec formatter?
+### Extra gems
 
-You may be familiar with using the `rspec -f` flag to change the rspec formatter. RSpec also offers a way to set the formatter from your specs:
+If a `Gemfile` is present in the suite directory, it is `bundle install`ed
+before the run. Remember to include RSpec itself:
+
+```ruby
+source "https://rubygems.org"
+
+gem "rspec"
+```
+
+The install is attempted with `--local` first and falls back to the network, so
+gems already present on the machine do not cost a download.
+
+### Chef setup
+
+If a `setup-recipe.rb` is present in the suite directory, it is applied with
+`chef-apply` before the specs run. This requires `/opt/chef/bin/chef-apply` on
+the machine; the run fails with a clear error if the file is there and Chef is
+not.
+
+### Changing the formatter
+
+`rspec -f` is not available here, since Busser invokes the runner itself. Set
+the formatter from your specs instead:
 
 ```ruby
 RSpec.configure do |config|
-  # The same as `rspec -f documentation`
+  # the same as `rspec -f documentation`
   config.add_formatter "documentation"
+end
 ```
 
-## Development
+## Contributing
 
-* Source hosted at [GitHub](https://github.com/opscode/busser-rspec)
-* Report issues/questions/feature requests on [GitHub Issues](issues)
-
-Pull requests are very welcome! Make sure your patches are well tested.
-Ideally create a topic branch for every separate change you make. For
-example:
-
-1. Fork the repo
-2. Create your feature branch (`git checkout -b my-new-feature`)
-3. Commit your changes (`git commit -am 'Added some feature'`)
-4. Push to the branch (`git push origin my-new-feature`)
-5. Create new Pull Request
-
-## Authors
-
-Created and maintained by Adam Jacob (<adam@opscode.com>)
-
-Based on [busser-serverspec](https://github.com/cl-lab-k/busser-serverspec), created and maintained by HIGUCHI Daisuke (<d-higuchi@creationline.com>)
+Bug reports and pull requests are welcome. See
+[CONTRIBUTING.md](CONTRIBUTING.md) for how to set up the project, run the test
+suite, and format your commits.
 
 ## License
 
-Apache 2.0 (see [LICENSE](license))
+Apache License 2.0. See [LICENSE](LICENSE).
 
+Originally created by [Adam Jacob](https://github.com/adamhjk), based on
+[Daisuke Higuchi](https://github.com/cl-lab-k)'s
+[busser-serverspec](https://github.com/test-kitchen/busser-serverspec).

--- a/Rakefile
+++ b/Rakefile
@@ -2,7 +2,7 @@ require "bundler/gem_tasks"
 require "cucumber/rake/task"
 
 Cucumber::Rake::Task.new(:features) do |t|
-  t.cucumber_opts = ["features", "-x", "--format progress"]
+  t.cucumber_opts = ["features", "--format progress", "--fail-fast"]
 end
 
 desc "Run all test suites"

--- a/features/support/env.rb
+++ b/features/support/env.rb
@@ -11,13 +11,6 @@ Aruba.configure do |config|
   config.exit_timeout = 120
 end
 
-After do |s|
-  # Tell Cucumber to quit after this scenario is done - if it failed.
-  # This is useful to inspect the 'tmp/aruba' directory before any other
-  # steps are executed and clear it out.
-  Cucumber.wants_to_quit = true if s.failed?
-end
-
 # The sandboxed features shell out to `busser plugin install <this plugin>`, and
 # two things have to hold for that to exercise this checkout:
 #


### PR DESCRIPTION
The README was a mix of usage docs and a generic fork-and-branch section, with
links still pointing at pre-transfer repositories and `master`. It is now just
what a user of the plugin needs: what it does, what it requires, where tests go,
and what a passing test looks like. Everything a contributor needs moved to a
new CONTRIBUTING.md, modelled on the one in test-kitchen/busser -- how to set the
project up, how to run the suite, the linters CI runs, and the Conventional
Commits convention release-please reads.

Every development dependency now carries a version floor at its current major,
so a resolver cannot quietly pick an ancient release: cookstyle 9, aruba 2.4,
cucumber 11.1, rake 13.4, simplecov 1.1.

Test tooling brought up to date:

* `.rubocop.yml` targeted Ruby 3.1 while the gemspec requires 3.2.
* The `After` hook setting `Cucumber.wants_to_quit` is replaced by cucumber's
  own `--fail-fast`, which is the supported way to stop at the first failure.
* `-x` (`--expand`) is dropped; it only affects Scenario Outline output and
  there are no outlines here.

`.tailor` is removed. It configured the tailor gem, which has been unmaintained
since 2014 and is not in the bundle, so the file did nothing.