### PR TITLE
chore: remove code coverage entirely

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,7 +6,6 @@
 Gemfile.lock
 InstalledFiles
 _yardoc
-coverage
 doc/
 lib/bundler/man
 pkg


### PR DESCRIPTION
chore: remove code coverage entirely

Nothing consumed it. Coverage only ran when COVERAGE was set in the
environment, no CI job set it, the coveralls integration that once reported the
numbers is long gone, and these plugins are small enough that a percentage was
never going to drive a decision. What was left was a dependency and a block of
setup that had to be kept working for no return.

Removed: the simplecov development dependency, the COVERAGE block in
features/support/env.rb, and the coverage entry in .gitignore now that nothing
writes that directory.