### PR TITLE
test: cover the runner command construction

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,6 +10,8 @@ group :test do
   gem "aruba", ">= 2.4"
   gem "base64", ">= 0.3" # cucumber needs it; not a default gem on Ruby 4.0
   gem "cucumber", ">= 11.1"
+  gem "minitest", ">= 6.0"
+  gem "mocha", ">= 2.7"
   gem "rake", ">= 13.4"
   gem "rspec", ">= 3.13"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,4 +1,11 @@
 require "bundler/gem_tasks"
+require "rake/testtask"
+Rake::TestTask.new(:unit) do |t|
+  t.libs.push "lib"
+  t.test_files = FileList["spec/**/*_spec.rb"]
+  t.verbose = true
+end
+
 require "cucumber/rake/task"
 
 Cucumber::Rake::Task.new(:features) do |t|
@@ -6,6 +13,6 @@ Cucumber::Rake::Task.new(:features) do |t|
 end
 
 desc "Run all test suites"
-task test: [:features]
+task test: %i{unit features}
 
 task default: [:test]

--- a/lib/busser/runner_plugin/rspec.rb
+++ b/lib/busser/runner_plugin/rspec.rb
@@ -17,12 +17,37 @@
 
 require "busser/runner_plugin"
 require "rubygems" unless defined?(Gem)
+require "shellwords" unless defined?(Shellwords)
 
 # A Busser runner plugin for Rspec.
 #
 # @author Adam Jacob <adam@opscode.com>
 #
 class Busser::RunnerPlugin::Rspec < Busser::RunnerPlugin::Base
+
+  # Builds the command that runs the suite.
+  #
+  # The suite directory goes on the load path twice -- itself and its lib
+  # subdirectory -- so `require "spec_helper"` works from any spec without a
+  # relative path.
+  #
+  # Every path is quoted. BUSSER_ROOT is user supplied, and an unquoted path
+  # containing a space would be split by the shell into arguments RSpec would
+  # then treat as extra spec paths.
+  #
+  # @param runner [String] path to the runner script
+  # @param suite [String, Pathname] the suite directory holding the specs
+  # @return [String] the command to run
+  def self.runner_command(runner, suite)
+    suite = suite.to_s
+    [
+      Shellwords.escape(runner),
+      "-I", Shellwords.escape(suite),
+      "-I", Shellwords.escape(File.join(suite, "lib")),
+      Shellwords.escape(suite)
+    ].join(" ")
+  end
+
   postinstall do
     install_gem("rspec", ">= 3.13")
     install_gem("bundler")
@@ -57,7 +82,7 @@ class Busser::RunnerPlugin::Rspec < Busser::RunnerPlugin::Base
       end
 
       runner = File.expand_path(File.join(File.dirname(__FILE__), "..", "rspec", "runner.rb"))
-      run_ruby_script!("#{runner} -I #{rspec_path} -I #{rspec_path}/lib #{rspec_path}")
+      run_ruby_script!(self.class.runner_command(runner, rspec_path))
     end
   end
 end

--- a/spec/busser/runner_plugin/rspec_spec.rb
+++ b/spec/busser/runner_plugin/rspec_spec.rb
@@ -1,0 +1,45 @@
+require_relative "../../spec_helper"
+
+require "shellwords"
+require "busser/runner_plugin/rspec"
+
+describe Busser::RunnerPlugin::Rspec do
+  describe ".runner_command" do
+    let(:cmd) do
+      Busser::RunnerPlugin::Rspec.runner_command("/gems/busser-rspec/lib/busser/rspec/runner.rb",
+        "/opt/busser/suites/rspec")
+    end
+
+    it "runs the runner script against the suite" do
+      _(Shellwords.split(cmd)).must_equal [
+        "/gems/busser-rspec/lib/busser/rspec/runner.rb",
+        "-I", "/opt/busser/suites/rspec",
+        "-I", "/opt/busser/suites/rspec/lib",
+        "/opt/busser/suites/rspec",
+      ]
+    end
+
+    # Documented behaviour: spec_helper.rb is required without a relative path,
+    # which only works while the suite is on the load path.
+    it "puts the suite and its lib directory on the load path" do
+      _(Shellwords.split(cmd).each_cons(2).select { |flag, _| flag == "-I" }.map(&:last))
+        .must_equal ["/opt/busser/suites/rspec", "/opt/busser/suites/rspec/lib"]
+    end
+
+    it "quotes a suite path containing spaces" do
+      cmd = Busser::RunnerPlugin::Rspec.runner_command("/a/runner.rb", "/tmp/my tests/rspec")
+
+      _(Shellwords.split(cmd)).must_equal [
+        "/a/runner.rb",
+        "-I", "/tmp/my tests/rspec",
+        "-I", "/tmp/my tests/rspec/lib",
+        "/tmp/my tests/rspec",
+      ]
+    end
+
+    it "accepts a Pathname suite" do
+      cmd = Busser::RunnerPlugin::Rspec.runner_command("/a/runner.rb", Pathname.new("/b/rspec"))
+      _(Shellwords.split(cmd).last).must_equal "/b/rspec"
+    end
+  end
+end

--- a/spec/busser/runner_plugin/rspec_spec.rb
+++ b/spec/busser/runner_plugin/rspec_spec.rb
@@ -15,7 +15,7 @@ describe Busser::RunnerPlugin::Rspec do
         "/gems/busser-rspec/lib/busser/rspec/runner.rb",
         "-I", "/opt/busser/suites/rspec",
         "-I", "/opt/busser/suites/rspec/lib",
-        "/opt/busser/suites/rspec",
+        "/opt/busser/suites/rspec"
       ]
     end
 
@@ -33,7 +33,7 @@ describe Busser::RunnerPlugin::Rspec do
         "/a/runner.rb",
         "-I", "/tmp/my tests/rspec",
         "-I", "/tmp/my tests/rspec/lib",
-        "/tmp/my tests/rspec",
+        "/tmp/my tests/rspec"
       ]
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,0 +1,2 @@
+require "minitest/autorun"
+require "mocha/minitest"


### PR DESCRIPTION
These plugins had no unit tests at all -- every check was an end-to-end cucumber
feature that boots busser, installs a plugin into a sandbox and runs a suite.
That is the right shape for proving the plugin works, but it is slow and it
cannot easily probe the edges where regressions actually live, such as exactly
which filenames a glob selects.

This adds a `spec/` suite using minitest and mocha, matching what
test-kitchen/busser already does, and wires `rake unit` in alongside
`rake features`. `rake test` runs both. The aim is not coverage; every test here
is one that fails if a specific behaviour regresses.

Where the logic under test lived inside a script that executes on load, it moved
into a small module the script requires, so it can be exercised without running
a suite.

## The bug this found

The command was built by interpolation:

```ruby
run_ruby_script!("#{runner} -I #{rspec_path} -I #{rspec_path}/lib #{rspec_path}")
```

BUSSER_ROOT is user supplied. A suite path containing a space was split by the
shell, and the fragments were then treated by RSpec as additional spec paths.
`runner_command` now escapes every path with `Shellwords`.

## What is covered

Four tests, asserting on `Shellwords.split(cmd)` -- what a shell would actually
see -- rather than on the escaped string. They pin the argument order, the two
`-I` entries that make `require "spec_helper"` work without a relative path (a
documented behaviour), and that a spaced path survives as one argument.