### PR TITLE
docs: document every method with YARD and add a docs rake task

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,3 +15,7 @@ group :test do
   gem "rake", ">= 13.4"
   gem "rspec", ">= 3.13"
 end
+
+group :development do
+  gem "yard", ">= 0.9.37"
+end

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,24 @@ Cucumber::Rake::Task.new(:features) do |t|
   t.cucumber_opts = ["features", "--format progress", "--fail-fast"]
 end
 
+# yard lives in the :development group, which CI omits when it runs the tests.
+# Requiring it unconditionally would make `rake test` fail there, so the real
+# task is only defined when yard is installed and a stub explains its absence
+# otherwise. Nothing in CI gates on documentation.
+begin
+  require "yard"
+
+  YARD::Rake::YardocTask.new(:doc) do |t|
+    t.files = ["lib/**/*.rb"]
+    t.options = ["--output-dir", "doc", "--markup", "markdown"]
+  end
+rescue LoadError
+  desc "Generate YARD documentation (install the development group first)"
+  task :doc do
+    abort "yard is not available. Run `bundle install --with development` first."
+  end
+end
+
 desc "Run all test suites"
 task test: %i{unit features}
 

--- a/lib/busser/rspec/version.rb
+++ b/lib/busser/rspec/version.rb
@@ -17,6 +17,7 @@
 
 module Busser
 
+  # Namespace for the RSpec Busser runner plugin.
   module Rspec
 
     # Version string for the Rspec Busser runner plugin

--- a/lib/busser/runner_plugin/rspec.rb
+++ b/lib/busser/runner_plugin/rspec.rb
@@ -48,11 +48,23 @@ class Busser::RunnerPlugin::Rspec < Busser::RunnerPlugin::Base
     ].join(" ")
   end
 
+  # Installs RSpec and bundler onto the machine under test. Runs once, when
+  # Busser installs this plugin.
   postinstall do
     install_gem("rspec", ">= 3.13")
     install_gem("bundler")
   end
 
+  # Runs the suite's specs.
+  #
+  # If the suite ships a Gemfile its gems are installed first, and if it ships a
+  # setup-recipe.rb that recipe is applied with chef-apply to put the machine
+  # into a known state.
+  #
+  # @raise [RuntimeError] if a setup recipe is present but chef-apply is not
+  #   installed, since running the specs against an unprepared machine would
+  #   produce misleading failures
+  # @return [void]
   def test
     rspec_path = suite_path("rspec").to_s
 
@@ -75,7 +87,7 @@ class Busser::RunnerPlugin::Rspec < Busser::RunnerPlugin::Base
 
       if File.exist?(setup_file)
         unless File.exist?("/opt/chef/bin/chef-apply")
-          raise "You have a chef setup file at #{setup_file}, but /opt/chef/bin/chef-apply does not if exist"
+          raise "You have a chef setup file at #{setup_file}, but /opt/chef/bin/chef-apply does not exist"
         end
 
         run("/opt/chef/bin/chef-apply #{setup_file}")


### PR DESCRIPTION
docs: document every method with YARD and add a docs rake task

Nothing in this repository carried API documentation beyond a stray author tag.
Every method now has a YARD comment covering what it does, what it takes, what
it returns, and -- where it matters -- why it is written the way it is. `yard
stats --private` reports 100% documented.

`rake doc` generates the HTML into `doc/`, which is already gitignored.

yard sits in the `:development` bundler group, which CI omits when it runs the
tests, so the Rakefile only defines the real task when yard is installed and
otherwise leaves a stub that says how to get it. **Nothing in CI gates on
documentation**, and `rake test` still works with the group omitted -- verified
by running it under `BUNDLE_WITHOUT=development`, the same setting the shared
workflow uses.

Also fixes a twelve-year-old typo in an error message: "chef-apply does not if
exist" now reads "does not exist". Same wording was in busser-rspec.