### PR TITLE
fix: quote paths before handing them to a shell

### DIFF
--- a/lib/busser/runner_plugin/rspec.rb
+++ b/lib/busser/runner_plugin/rspec.rb
@@ -17,6 +17,7 @@
 
 require "busser/runner_plugin"
 require "rubygems" unless defined?(Gem)
+require "rbconfig" unless defined?(RbConfig)
 require "shellwords" unless defined?(Shellwords)
 
 # A Busser runner plugin for Rspec.
@@ -50,6 +51,36 @@ class Busser::RunnerPlugin::Rspec < Busser::RunnerPlugin::Base
 
   # Installs RSpec and bundler onto the machine under test. Runs once, when
   # Busser installs this plugin.
+  # Builds the chef-apply command for a suite's setup recipe.
+  #
+  # @param setup_file [String, Pathname] path to the setup recipe
+  # @return [String] the command to run
+  def self.chef_apply_command(setup_file)
+    "/opt/chef/bin/chef-apply #{Shellwords.escape(setup_file.to_s)}"
+  end
+
+  # Builds the bundle install command for a suite's own Gemfile.
+  #
+  # bundler is invoked through the Ruby running Busser rather than whatever
+  # `bundle` is on PATH, since on a machine with several Rubies those differ and
+  # the suite's gems would land where the runner cannot see them.
+  #
+  # The --local attempt is a speed optimisation: it finishes immediately when
+  # the gems are already present and fails when it would need the network, so
+  # the second attempt is the fallback.
+  #
+  # @param gemfile [String, Pathname] path to the suite's Gemfile
+  # @return [String] the command to run
+  def self.bundle_install_command(gemfile)
+    bundle = [
+      Shellwords.escape(File.join(RbConfig::CONFIG["bindir"], "ruby")),
+      Shellwords.escape(File.join(Gem.bindir, "bundle")),
+      "install", "--gemfile", Shellwords.escape(gemfile.to_s)
+    ].join(" ")
+
+    "#{bundle} --local || #{bundle}"
+  end
+
   postinstall do
     install_gem("rspec", ">= 3.13")
     install_gem("bundler")
@@ -80,9 +111,7 @@ class Busser::RunnerPlugin::Rspec < Busser::RunnerPlugin::Base
         # to the internet-enabled version. It's a speed optimization.
         banner("Bundle Installing..")
         ENV["PATH"] = [ENV["PATH"], Gem.bindir, RbConfig::CONFIG["bindir"]].join(File::PATH_SEPARATOR)
-        bundle_exec = "#{File.join(RbConfig::CONFIG["bindir"], "ruby")} " +
-          "#{File.join(Gem.bindir, "bundle")} install --gemfile #{gemfile_path}"
-        run("#{bundle_exec} --local || #{bundle_exec}")
+        run(self.class.bundle_install_command(gemfile_path))
       end
 
       if File.exist?(setup_file)
@@ -90,7 +119,7 @@ class Busser::RunnerPlugin::Rspec < Busser::RunnerPlugin::Base
           raise "You have a chef setup file at #{setup_file}, but /opt/chef/bin/chef-apply does not exist"
         end
 
-        run("/opt/chef/bin/chef-apply #{setup_file}")
+        run(self.class.chef_apply_command(setup_file))
       end
 
       runner = File.expand_path(File.join(File.dirname(__FILE__), "..", "rspec", "runner.rb"))

--- a/spec/busser/runner_plugin/rspec_spec.rb
+++ b/spec/busser/runner_plugin/rspec_spec.rb
@@ -1,5 +1,6 @@
 require_relative "../../spec_helper"
 
+require "rbconfig"
 require "shellwords"
 require "busser/runner_plugin/rspec"
 
@@ -40,6 +41,47 @@ describe Busser::RunnerPlugin::Rspec do
     it "accepts a Pathname suite" do
       cmd = Busser::RunnerPlugin::Rspec.runner_command("/a/runner.rb", Pathname.new("/b/rspec"))
       _(Shellwords.split(cmd).last).must_equal "/b/rspec"
+    end
+  end
+
+  describe ".chef_apply_command" do
+    it "applies the setup recipe with chef-apply" do
+      cmd = Busser::RunnerPlugin::Rspec.chef_apply_command("/suite/setup-recipe.rb")
+
+      _(Shellwords.split(cmd))
+        .must_equal ["/opt/chef/bin/chef-apply", "/suite/setup-recipe.rb"]
+    end
+
+    it "quotes a path containing spaces" do
+      cmd = Busser::RunnerPlugin::Rspec.chef_apply_command("/tmp/my tests/setup-recipe.rb")
+
+      _(Shellwords.split(cmd).last).must_equal "/tmp/my tests/setup-recipe.rb"
+    end
+  end
+
+  describe ".bundle_install_command" do
+    let(:cmd) { Busser::RunnerPlugin::Rspec.bundle_install_command("/suite/Gemfile") }
+
+    it "invokes bundler through the running Ruby rather than PATH" do
+      first, second = Shellwords.split(cmd).first(2)
+
+      _(first).must_equal File.join(RbConfig::CONFIG["bindir"], "ruby")
+      _(second).must_equal File.join(Gem.bindir, "bundle")
+    end
+
+    it "names the suite's Gemfile explicitly" do
+      _(Shellwords.split(cmd)).must_include "/suite/Gemfile"
+    end
+
+    it "falls back from the local attempt to a networked one" do
+      _(cmd).must_include "--local || "
+      _(cmd.scan("--gemfile").length).must_equal 2
+    end
+
+    it "quotes a Gemfile path containing spaces" do
+      cmd = Busser::RunnerPlugin::Rspec.bundle_install_command("/tmp/my tests/Gemfile")
+
+      _(Shellwords.split(cmd.split(" || ").first)).must_include "/tmp/my tests/Gemfile"
     end
   end
 end


### PR DESCRIPTION
fix: quote paths before handing them to a shell

Two commands interpolated paths raw: the chef-apply call for a suite setup
recipe and the bundle install for a suite Gemfile. Both paths are rooted at
BUSSER_ROOT, which the caller chooses and Test Kitchen places under a
user-controlled directory, so a space anywhere in it split the command and the
tool was handed a fragment.

Each now comes from a class method that escapes with Shellwords, which also
makes them testable without running a suite. Six specs cover them, asserting on
Shellwords.split -- what a shell would actually see -- rather than on escaping
syntax.

The runner invocation was already quoted; this brings the rest of the file in
line with it.