### PR TITLE
docs: add the Test Kitchen path and a "nothing ran" guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,48 @@ RSpec.configure do |config|
 end
 ```
 
+## Using it with Test Kitchen
+
+This is how most people run it, and it needs no Busser commands of your own.
+Select the verifier in `kitchen.yml`:
+
+```yaml
+verifier:
+  name: busser
+
+suites:
+  - name: default
+```
+
+Then put your tests in a `rspec` directory inside the suite:
+
+```text
+test/integration/default/rspec/default_spec.rb
+```
+
+`kitchen verify` installs Busser and this plugin on the instance and runs them.
+The directory name is what selects this plugin -- there is nothing else to
+configure.
+
+## When nothing runs
+
+If the suite files do not match what this plugin looks for, the run prints one
+line and **exits `0`**:
+
+```text
+-----> Running rspec test suite
+```
+
+No tests ran, and nothing said so. Work through these in order:
+
+1. **Is the directory named `rspec`?** That name alone selects this plugin.
+   `rspecs/`, `tests/` or anything else is not picked up.
+2. **Do the filenames match?** RSpec takes `*_spec.rb` -- `smoke.rb` is
+   *not* picked up.
+3. **Is the plugin installed?** `busser plugin list` shows what is available.
+4. **Is `BUSSER_ROOT` what you think?** `busser suite path` prints where suites
+   are actually being looked for.
+
 ## Contributing
 
 Bug reports and pull requests are welcome. See


### PR DESCRIPTION
docs: add the Test Kitchen path and a "nothing ran" guide

The README described the layout and the glob accurately but never joined them
up. Someone arriving at this plugin could read it end to end and still not know
how it gets invoked, or what to do when a suite appears to be skipped.

**Using it with Test Kitchen.** This is how nearly everyone runs these plugins,
and the README never mentioned it -- no `kitchen.yml`, no `verifier:` block, no
statement that the suite directory name alone is what selects the plugin.

**When nothing runs.** The most confusing failure in the family: a suite whose
filenames do not match the glob prints one banner line and **exits `0`**. Green,
and no tests ran. The section shows exactly that output and walks the four
causes in order -- wrong directory name, wrong filename pattern, plugin not
installed, unexpected BUSSER_ROOT -- naming the two commands that answer the
last two.

The `exits 0` behaviour was confirmed by running it, not assumed.