### PR TITLE
chore: stop Renovate opening dependency dashboard issues

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    ":disableDependencyDashboard",
     "helpers:pinGitHubActionDigests",
     ":semanticCommits"
   ]


### PR DESCRIPTION
chore: stop Renovate opening dependency dashboard issues

config:recommended turns the dependency dashboard on, so Renovate keeps an
issue open in every repository restating what its pull requests already say.
Across seven repositories that is seven standing issues nobody reads.

`:disableDependencyDashboard` turns it off. Renovate still opens the update
pull requests exactly as before; it just stops narrating them in an issue.