### PR TITLE
test: verify the plugin works with Test Kitchen in CI

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,0 +1,50 @@
+---
+name: "Test Kitchen"
+
+"on":
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  kitchen:
+    name: "kitchen verify on Ruby ${{ matrix.ruby }}"
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # The ends of the supported range. The unit and feature suites already
+        # cover everything in between; this job is about the Test Kitchen
+        # integration, not Ruby compatibility.
+        ruby: ["3.2", "4.0"]
+    env:
+      BUSSER_ROOT: ${{ github.workspace }}/tmp/busser-kitchen
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
+
+      # Deliberately no bundler-cache, and nothing below runs under `bundle
+      # exec`. The verifier shells out to `gem list` to decide what to install,
+      # and bundler in the environment makes that report the bundle's gems
+      # rather than the Busser root's -- so it skips installing busser and the
+      # run dies on a path that was never created. Test Kitchen is not run from
+      # inside a project's bundle in real use either.
+      - uses: ruby/setup-ruby@95ef2b042f9d7a56d8268cba8559e2842e2ad01b  # v1.321.0
+        with:
+          ruby-version: ${{ matrix.ruby }}
+
+      - name: Install Test Kitchen
+        run: gem install test-kitchen --no-document --version "~> 4.1"
+
+      - name: Install this working tree into the Busser root
+        run: ./kitchen-preinstall.sh
+
+      - name: kitchen verify
+        run: kitchen verify

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -26,7 +26,12 @@ jobs:
         # integration, not Ruby compatibility.
         ruby: ["3.2", "4.0"]
     env:
-      BUSSER_ROOT: ${{ github.workspace }}/tmp/busser-kitchen
+      # Outside the checkout on purpose. The runners require "bundler/setup",
+      # which walks up from the suite looking for a Gemfile -- so a Busser root
+      # inside the workspace finds this project's Gemfile and tries to
+      # materialize that bundle inside the isolated gem home, which fails. A
+      # real Busser root is /opt/busser, never inside the project.
+      BUSSER_ROOT: /tmp/busser-kitchen
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
 

--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ spec/reports
 test/tmp
 test/version_tmp
 tmp
+.kitchen/

--- a/kitchen-preinstall.sh
+++ b/kitchen-preinstall.sh
@@ -1,0 +1,55 @@
+#!/usr/bin/env bash
+# Installs this working tree into the Busser root the Test Kitchen verifier
+# will use, so `kitchen verify` exercises the code on this branch rather than
+# the last release from RubyGems.
+#
+# The verifier's install script skips its own install when `gem list` already
+# shows what it wants, so putting things in place first is all that is needed.
+# Two consequences to handle:
+#
+#   * It also has to install busser itself. That check is `grep "^busser"` with
+#     no anchor at the end, so a plugin named busser-* satisfies it and busser
+#     would otherwise never be installed at all.
+#   * Skipping `busser plugin install` also skips the plugin's postinstall,
+#     which is where a plugin installs the test framework it drives. So run the
+#     postinstall here, which is what the verifier would have done.
+set -euo pipefail
+
+BUSSER_ROOT="${BUSSER_ROOT:-/tmp/busser-kitchen}"
+gemspec="$(ls ./*.gemspec)"
+gem_name="$(basename "${gemspec}" .gemspec)"
+
+install_opts=(
+  --install-dir "${BUSSER_ROOT}/gems"
+  --bindir "${BUSSER_ROOT}/bin"
+  --no-document
+)
+
+mkdir -p "${BUSSER_ROOT}/gems"
+
+gem build "${gemspec}" --output "${BUSSER_ROOT}/${gem_name}.gem" >/dev/null
+
+if [ "${gem_name}" = "busser" ]; then
+  # No --local: a plugin's runtime dependencies are things its runner needs on
+  # the machine under test, and they have to be fetched into the Busser root
+  # like everything else.
+  gem install "${BUSSER_ROOT}/${gem_name}.gem" "${install_opts[@]}" >/dev/null
+else
+  gem install busser "${install_opts[@]}" >/dev/null
+  # Not --ignore-dependencies: a plugin's runtime dependencies are things its
+  # runner needs on the machine under test, and they have to be in the Busser
+  # root like everything else.
+  # No --local: a plugin's runtime dependencies are things its runner needs on
+  # the machine under test, and they have to be fetched into the Busser root
+  # like everything else.
+  gem install "${BUSSER_ROOT}/${gem_name}.gem" "${install_opts[@]}" >/dev/null
+
+  # The same environment the verifier exports, so the framework this plugin
+  # installs lands in the Busser root rather than the ambient gem home.
+  BUSSER_ROOT="${BUSSER_ROOT}" \
+    GEM_HOME="${BUSSER_ROOT}/gems" \
+    GEM_PATH="${BUSSER_ROOT}/gems" \
+    "${BUSSER_ROOT}/bin/busser" plugin install "${gem_name}" --force-postinstall
+fi
+
+echo "pre-installed ${gem_name} from the working tree into ${BUSSER_ROOT}"

--- a/kitchen.yml
+++ b/kitchen.yml
@@ -1,0 +1,23 @@
+---
+# Runs the RSpec runner the way Test Kitchen actually runs it -- real verifier,
+# real busser, real suite transfer -- but against the machine running the tests
+# rather than a VM or container, so it works unchanged in CI.
+driver:
+  name: exec
+
+provisioner:
+  name: dummy
+
+verifier:
+  name: busser
+  # The verifier defaults to Chef's omnibus Ruby, which is not what is running
+  # here, and to sudo, which is not needed for a path under the workspace.
+  ruby_bindir: <%= RbConfig::CONFIG["bindir"] %>
+  sudo: false
+  root_path: <%= ENV.fetch("BUSSER_ROOT", "/tmp/busser-kitchen") %>
+
+platforms:
+  - name: local
+
+suites:
+  - name: default

--- a/renovate.json
+++ b/renovate.json
@@ -2,6 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended",
+    ":disableDependencyDashboard",
     "helpers:pinGitHubActionDigests",
     ":semanticCommits"
   ]

--- a/test/integration/default/rspec/smoke_spec.rb
+++ b/test/integration/default/rspec/smoke_spec.rb
@@ -1,0 +1,12 @@
+require "spec_helper"
+
+# Runs on the machine under test through busser-rspec.
+describe "the rspec runner" do
+  it "reached the machine under test" do
+    expect(File).to exist(Dir.tmpdir)
+  end
+
+  it "loaded spec_helper without a relative path" do
+    expect(defined?(BUSSER_RSPEC_SMOKE)).to eq("constant")
+  end
+end

--- a/test/integration/default/rspec/spec_helper.rb
+++ b/test/integration/default/rspec/spec_helper.rb
@@ -1,0 +1,5 @@
+require "tmpdir"
+
+# Proves the suite directory is on the load path: smoke_spec.rb requires this
+# by name, with no relative path.
+BUSSER_RSPEC_SMOKE = true


### PR DESCRIPTION
These plugins exist to be run by Test Kitchen, and nothing in CI ever ran them
that way. The cucumber features drive `busser` directly, which covers the plugin
but skips the whole verifier path -- how Test Kitchen installs busser, installs
the plugin, transfers the suite and invokes it.

This adds a `kitchen verify` job that runs the real thing:

* **`driver: exec` with `transport: exec`**, both shipped with Test Kitchen, so
  the "machine under test" is the CI runner. No Docker, no VM, no credentials,
  a couple of seconds per run.
* **The real `busser` verifier**, pointed at the running Ruby rather than
  Chef's omnibus and told not to sudo for a path inside the workspace.
* **`kitchen-preinstall.sh`** puts this working tree into the Busser root first,
  so the job tests the branch rather than the last release from RubyGems.

`test/integration/default/` holds a small suite in the plugin's own language.

## Two things worth knowing about the setup

**It deliberately does not use bundler.** No `bundler-cache`, no `bundle exec`.
The verifier shells out to `gem list` to decide what to install, and bundler in
the environment makes that report the bundle's gems rather than the Busser
root's -- so it skips installing busser and the run dies on a path that was
never created. Test Kitchen is not run from inside a project's bundle in real
use either.

**The pre-install has to install busser itself and run the postinstall.** The
verifier's check is `grep "^busser"` with no anchor at the end, so a plugin
named `busser-*` satisfies it and busser would never be installed. And skipping
`busser plugin install` also skips the plugin's postinstall, which is where a
plugin installs the framework it drives.

Verified both directions locally: a passing suite exits 0, and a deliberately
failing test makes `kitchen verify` exit 20.

The suite requires `spec_helper` by name with no relative path, so it also
covers the load-path handling the README documents.